### PR TITLE
Bundle sassc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        submodules: true
 
     - name: Setup ruby
       uses: ruby/setup-ruby@v1
@@ -65,6 +67,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        submodules: true
 
     - name: Setup ruby
       uses: ruby/setup-ruby@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        submodules: true
 
     - name: Setup ruby
       uses: ruby/setup-ruby@v1

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,9 @@
 [submodule "vendor/github.com/sass/sassc-rails"]
 	path = vendor/github.com/sass/sassc-rails
 	url = https://github.com/sass/sassc-rails.git
+[submodule "vendor/github.com/sass/sassc-ruby"]
+	path = vendor/github.com/sass/sassc-ruby
+	url = https://github.com/sass/sassc-ruby.git
 [submodule "vendor/github.com/twbs/bootstrap"]
 	path = vendor/github.com/twbs/bootstrap
 	url = https://github.com/twbs/bootstrap.git

--- a/sassc-embedded.gemspec
+++ b/sassc-embedded.gemspec
@@ -17,13 +17,15 @@ Gem::Specification.new do |spec| # rubocop:disable Gemspec/RequireMFA
     'funding_uri' => 'https://github.com/sponsors/ntkme'
   }
 
-  spec.files = Dir['lib/**/*.rb'] + [
+  spec.files = Dir['lib/**/*.rb', 'vendor/github.com/sass/sassc-ruby/lib/**/*.rb'] + [
     'LICENSE',
-    'README.md'
+    'README.md',
+    'vendor/github.com/sass/sassc-ruby/LICENSE.txt'
   ]
+
+  spec.require_paths = ['lib', 'vendor/github.com/sass/sassc-ruby/lib']
 
   spec.required_ruby_version = '>= 3.0.0'
 
-  spec.add_runtime_dependency 'sassc', '~> 2.0'
   spec.add_runtime_dependency 'sass-embedded', '~> 1.68'
 end


### PR DESCRIPTION
This PR bundles modified `sassc` from https://github.com/sass/sassc-ruby/pull/233 as part of `sassc-embedded`, so that installing a copy of original `sassc` would no longer be required.