### PR TITLE
Run single-use compiler process

### DIFF
--- a/lib/sassc/embedded.rb
+++ b/lib/sassc/embedded.rb
@@ -15,7 +15,9 @@ module SassC
 
       base_importer = import_handler.setup(nil)
 
-      result = ::Sass.compile_string(
+      sass = ::Sass::Embedded.new
+
+      result = sass.compile_string(
         @template,
         importer: base_importer,
         load_paths: load_paths,
@@ -64,6 +66,8 @@ module SassC
                URL.file_urls_to_relative_path(url, URL.path_to_file_url("#{Dir.pwd}/"))
              end
       raise SyntaxError.new(e.full_message, filename: path, line: line)
+    ensure
+      sass&.close
     end
 
     def dependencies


### PR DESCRIPTION
This PR avoids any long-lived process running in the background. It would make multiple compilations on same ruby process slower because it runs a new compiler for every single complication.

- Closes https://github.com/ntkme/sass-embedded-host-ruby/issues/173