### PR TITLE
FEATURE: Add option to disable source map path validation

### DIFF
--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -182,6 +182,32 @@ module SassC
       refute_match(/sourceMappingURL/, output)
     end
 
+    def test_source_map_without_path_validation
+      temp_dir('admin')
+
+      temp_file('admin/text-color.scss', <<~SCSS)
+        p {
+          color: red;
+        }
+      SCSS
+      temp_file('style.scss', <<~SCSS)
+        @import 'admin/text-color';
+
+        p {
+          padding: 20px;
+        }
+      SCSS
+      engine = Engine.new(File.read('style.scss'), {
+                            source_map_file: 'style.scss.map?foo=bar',
+                            source_map_contents: true,
+                            validate_source_map_path: false
+                          })
+      output = engine.render
+
+      assert_match(/"version":3/, engine.source_map)
+      assert_match(/style.scss.map\?foo\=bar/, output)
+    end
+
     def test_load_paths
       temp_dir('included_1')
       temp_dir('included_2')


### PR DESCRIPTION
Source map URLs have an extra path check that the stylesheet URLs don't. In our use case in Discourse, this extra check prevents us from using this gem. We need to pass query parameters for both stylesheets and source maps because we run Rails multisite and therefore need to direct traffic to the correct database. We use a `?__ws=hostname` parameter to do so currently using `dartsass-ruby`. This feature is the only blocker for us moving to using this repo (thanks so much for the process fix and for all your work here). 

Example usage: 

```ruby
Engine.new(File.read('style.scss'), {
  source_map_file: 'style.scss.map?foo=bar',
  source_map_contents: true,
  validate_source_map_path: false
})
```

The default behaviour is unchanged, path validation is skipped only when `validate_source_map_path: false`. 

--- 

Most of the code here was initially written by @xfalcox in https://github.com/tablecheck/dartsass-ruby/commit/e8a84b3d780fbf051af30f3ac215e8878e51ce63, I just added a test. Full disclosure, Falco and myself both work at Discourse.